### PR TITLE
Vagrantfile for setting up a machine with pre-configured examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ Examples
 
 Instructions for reproducing the examples use the [vagrant](http://reprozip.readthedocs.io/en/stable/unpacking.html#the-vagrant-unpacker-building-a-virtual-machine) and the [docker](http://reprozip.readthedocs.io/en/stable/unpacking.html#the-docker-unpacker-building-a-docker-container) unpackers. However, any of the [available unpackers](http://reprozip.readthedocs.io/en/stable/unpacking.html#unpackers) can be used.
 
+Vagrant Machine
+---------------
+
+This repository contains a [Vagrantfile](Vagrantfile) that automatically configures a machine with the following examples:
+
+* [bechdel-test](bechdel-test)
+* [bus-vis](bus-vis)
+* [digits-sklearn](digits-sklearn)
+* [digits-sklearn-opencv](digits-sklearn-opencv)
+* [irish-schools](irish-schools)
+* [stacked-up](stacked-up)
+
+To startup the machine, make sure you have [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/) installed, and then run the following:
+
+    $ vagrant up
+
+Note that this will take some time for the first time, since all the dependencies will need to be properly installed. By default, the machine starts in headless mode (no UI visible on the host machine). To boot it with a GUI, uncomment the ``vb.gui = true`` line in the [Vagrantfile](Vagrantfile).
+
+Instructions on how to run each of the examples in this machine are available in their respective pages.
+
 Other Useful Links
 ------------------
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure('2') do |config|
-    config.vm.box = "bento/ubuntu-16.04"
+    config.vm.box = "vida-nyu/ubuntu-16.04-upstart"
 
     config.vm.provider "virtualbox" do |vb|
         vb.name = "reprozip-examples"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure('2') do |config|
+    config.vm.box = "bento/ubuntu-16.04"
+
+    config.vm.provider "virtualbox" do |vb|
+        vb.name = "reprozip-examples"
+        # vb.gui = true
+    end
+
+    config.vm.network "forwarded_port", guest: 8000, host: 8000
+    config.vm.synced_folder ".", "/home/vagrant/reprozip-examples"
+
+    config.vm.provision "shell", path: "install.sh", privileged: false
+end

--- a/bechdel-test/README.md
+++ b/bechdel-test/README.md
@@ -32,6 +32,13 @@ Then, run each script with Python, in the following order:
 
 Alternatively, you can run the data analysis step (step 2) directly using the data we provide in this repository.
 
+If you are using the Vagrant machine provided by this repository, run the following:
+
+    $ vagrant ssh
+    $ workon bechdel-test
+    $ cd reprozip-examples/bechdel-test/
+    $ python bechdel.py
+
 ReproZip Package
 ----------------
 

--- a/bechdel-test/requirements.txt
+++ b/bechdel-test/requirements.txt
@@ -1,7 +1,7 @@
-numpy
-pandas
-beautifulsoup4
-html5lib
-matplotlib
-requests
-statsmodels
+beautifulsoup4==4.5.1
+html5lib==0.999999999
+matplotlib==1.5.3
+numpy==1.11.1
+pandas==0.18.0
+requests==2.11.1
+statsmodels==0.6.1

--- a/bus-vis/README.md
+++ b/bus-vis/README.md
@@ -17,6 +17,15 @@ The application can be run as following:
     $ cd target/
     $ java -jar BusVis-0.5.1-desktop-jar-with-dependencies.jar  ## running
 
+If you are using the Vagrant machine provided by this repository, first, make sure you uncomment the ``vb.gui = true`` line in the [Vagrantfile](Vagrantfile) before running ``vagrant up``. Log in to the machine (username: ``vagrant``, password: ``vagrant``) and run the following:
+
+    $ startxfce4&
+
+Then, open the Terminal and run:
+
+    $ cd ~/BusVis/target/
+    $ java -jar BusVis-0.5.1-desktop-jar-with-dependencies.jar
+
 ReproZip Package
 ----------------
 

--- a/bus-vis/README.md
+++ b/bus-vis/README.md
@@ -23,7 +23,7 @@ If you are using the Vagrant machine provided by this repository, first, make su
 
 Then, open the Terminal and run:
 
-    $ cd ~/BusVis/target/
+    $ cd reprozip-examples/bus-vis/BusVis/target/
     $ java -jar BusVis-0.5.1-desktop-jar-with-dependencies.jar
 
 ReproZip Package

--- a/digits-sklearn-opencv/README.md
+++ b/digits-sklearn-opencv/README.md
@@ -14,7 +14,15 @@ The original experiment is composed by two steps:
 1. [Classification](generateClassifier.py): the SVM classifier is created.
 1. [Prediction](performRecognition.py): the values of hand-written digits from the input file are predicted and recognized ([output.jpg](output.jpg)).
 
-To run this experiment without ReproZip, you will need to first install [scikit-learn](http://scikit-learn.org/) and [OpenCV](http://opencv.org/), and then run each script with Python, in the aforementioned order.
+To run this experiment without ReproZip, you will need to first install [scikit-learn](http://scikit-learn.org/) and [OpenCV 3.0.0](http://opencv.org/), and then run each script with Python, in the aforementioned order.
+
+If you are using the Vagrant machine provided by this repository, run the following:
+
+    $ vagrant ssh
+    $ workon digits-sklearn-opencv
+    $ cd reprozip-examples/digits-sklearn-opencv/
+    $ python generateClassifier.py
+    $ python performRecognition.py
 
 ReproZip Package
 ----------------

--- a/digits-sklearn-opencv/requirements.txt
+++ b/digits-sklearn-opencv/requirements.txt
@@ -1,0 +1,4 @@
+numpy==1.11.1
+scikit-learn==0.17.1
+scipy==0.18.0
+scikit-image==0.12.3

--- a/digits-sklearn/README.md
+++ b/digits-sklearn/README.md
@@ -29,6 +29,16 @@ The confusion matrix is written to standard output as:
 
 To run this experiment without ReproZip, you will need to install [scikit-learn](http://scikit-learn.org/) and run each script with Python, in the aforementioned order.
 
+If you are using the Vagrant machine provided by this repository, run the following:
+
+    $ vagrant ssh
+    $ workon digits-sklearn
+    $ cd reprozip-examples/digits-sklearn/
+    $ python 01_getdata.py
+    $ python 02_classifier.py
+    $ python 03_predict.py
+    $ python 04_confusion_matrix.py
+
 ReproZip Package
 ----------------
 

--- a/digits-sklearn/requirements.txt
+++ b/digits-sklearn/requirements.txt
@@ -1,0 +1,3 @@
+numpy==1.11.1
+scikit-learn==0.17.1
+scipy==0.18.0

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo '>> Updating information about packages...' >&2
+sudo apt-get -y update
+echo '>> Installing dependencies...' >&2
+sudo apt-get -y install vim git python python-dev python-pip python-virtualenv build-essential libsqlite3-dev virtualenvwrapper python-numpy
+
+echo '>> Installing xfce4 and VirtualBox guest tools...' >&2
+sudo apt-get -y install xfce4 virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
+sudo sh -c 'echo "allowed_users=anybody" > /etc/X11/Xwrapper.config'
+
+echo '>> Setting up virtualenvwrapper...' >&2
+rm -rf .virtualenvs
+mkdir .virtualenvs
+echo -e "\nexport WORKON_HOME=$HOME/.virtualenvs\nsource /usr/share/virtualenvwrapper/virtualenvwrapper.sh" >>.bash_profile
+. .bash_profile
+
+cd reprozip-examples
+
+echo '>> Installing dependencies for digits-sklearn...' >&2
+cd digits-sklearn/
+mkvirtualenv --system-site-packages digits-sklearn
+pip install -r requirements.txt
+deactivate
+cd ..
+
+echo '>> Installing dependencies for digits-sklearn-opencv...' >&2
+cd digits-sklearn-opencv/
+sudo apt-get -y install python-opencv
+mkvirtualenv --system-site-packages digits-sklearn-opencv
+pip install -r requirements.txt
+deactivate
+cd ..
+
+echo '>> Installing dependencies for bechdel-test...' >&2
+mkvirtualenv --system-site-packages bechdel-test
+cd bechdel-test/
+pip install -r requirements.txt
+deactivate
+cd ..
+
+echo '>> Installing dependencies for irish-schools...' >&2
+sudo apt-get -y install r-base r-cran-ggplot2
+
+echo '>> Installing dependencies for bus-vis...' >&2
+cd bus-vis/
+sudo apt-get -y install default-jre default-jdk maven
+test -e BusVis || git clone https://github.com/JosuaKrause/BusVis.git
+cd BusVis/
+mvn clean package
+cd ../..
+
+echo '>> Installing dependencies for stacked-up...' >&2
+cd stacked-up
+mkvirtualenv --system-site-packages stacked-up
+test -e sdp_curricula || git clone https://github.com/fchirigati/sdp_curricula.git
+cd sdp_curricula
+sudo apt-get -y install postgresql-9.5 libpq-dev
+sudo -u postgres pg_dropcluster --stop 9.5 main
+sudo -u postgres pg_createcluster --port 5432 --locale en_US.UTF-8 --start 9.5 main
+DB_NAME=sdp_curricula
+sudo -u postgres createdb $DB_NAME
+sudo -u postgres psql $DB_NAME <<END
+CREATE ROLE vagrant LOGIN PASSWORD '@x1s2013';
+GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO vagrant;
+ALTER ROLE postgres WITH PASSWORD '@x1s2013';
+END
+sudo sh -c "echo 'local all all trust' >/etc/postgresql/9.5/main/pg_hba.conf"
+sudo sh -c "echo 'host all all 127.0.0.1/32 trust' >>/etc/postgresql/9.5/main/pg_hba.conf"
+sudo service postgresql restart
+pip install -r requirements.txt
+cat >manage.py <<'END'
+#!/home/vagrant/.virtualenvs/stacked-up/bin/python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sdp_curricula.settings")
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+END
+chmod +x manage.py
+pg_restore -d $DB_NAME sdp_curricula.dump # load all the data
+sudo /etc/init.d/postgresql stop
+deactivate

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 echo '>> Updating information about packages...' >&2
 sudo apt-get -y update
 echo '>> Installing dependencies...' >&2
-sudo apt-get -y install vim git python python-dev python-pip python-virtualenv build-essential libsqlite3-dev virtualenvwrapper python-numpy
+sudo apt-get -y install vim git python python-dev python-pip python-virtualenv build-essential libsqlite3-dev virtualenvwrapper python-numpy libffi-dev
 
 echo '>> Installing xfce4 and VirtualBox guest tools...' >&2
 sudo apt-get -y install xfce4 virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
@@ -85,3 +85,11 @@ chmod +x manage.py
 pg_restore -d $DB_NAME sdp_curricula.dump # load all the data
 sudo /etc/init.d/postgresql stop
 deactivate
+cd ../..
+
+echo '>> Installing reprozip...' >&2
+mkvirtualenv --system-site-packages reprozip
+pip install --upgrade reprozip reprounzip[all]
+mkdir $HOME/.bin
+ln -s $HOME/.virtualenvs/reprozip/bin/reprozip $HOME/.virtualenvs/reprozip/bin/reprounzip $HOME/.bin/
+echo -e 'PATH=$HOME/.bin:$PATH\nexport PATH' >>$HOME/.bash_profile

--- a/irish-schools/README.md
+++ b/irish-schools/README.md
@@ -40,6 +40,12 @@ rds, package.rds_2, package.rds_3, package.rds_4, package.rds_5, package.rds_6,
 package.rds_7, package.rds_8, package.rds_9, plyr, plyr.rdb, plyr.rdx, plyr.so,
 scales, scales.rdb, scales.rdx, scales.so, sysdata.rdx
 
+If you are using the Vagrant machine provided by this repository, do the following to run the experiment:
+
+    $ vagrant ssh
+    $ cd reprozip-examples/irish-schools/
+    $ Rscript NationalSchools_Wolf_2016.R
+
 ReproZip Package
 ----------------
 

--- a/stacked-up/README.md
+++ b/stacked-up/README.md
@@ -11,6 +11,15 @@ Implementation
 
 The website can be accessed [here](http://stackedup.org/), and the original implementation of the website is available [here](https://github.com/merbroussard/sdp_curricula). However, the ReproZip package that we provide is based on a [fork](https://github.com/fchirigati/sdp_curricula) of the original project implementation, which fixes some issues, such as missing dependencies.
 
+If you are using the Vagrant machine provided by this repository, do the following to run the example:
+
+    $ vagrant ssh
+    $ workon stacked-up
+    $ cd sdp_curricula/
+    $ ./runserver
+
+The app will be accessible on ``localhost:8111`` from any Web browser.
+
 ReproZip Package
 ----------------
 

--- a/stacked-up/README.md
+++ b/stacked-up/README.md
@@ -15,10 +15,10 @@ If you are using the Vagrant machine provided by this repository, do the followi
 
     $ vagrant ssh
     $ workon stacked-up
-    $ cd sdp_curricula/
+    $ cd reprozip-examples/stacked-up/sdp_curricula/
     $ ./runserver
 
-The app will be accessible on ``localhost:8111`` from any Web browser.
+The app will be accessible on ``localhost:8000`` from any Web browser.
 
 ReproZip Package
 ----------------


### PR DESCRIPTION
This provides updates to the Vagrantfile and to the installation script. It also updates the README files with instructions on how to run the examples in the machine.

All the examples were tested and work.
Packing with ReproZip has not been tested yet, but ReproZip is installed in the machine.
