### PR TITLE
Add the pre-built box to the Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,15 +2,25 @@
 # vi: set ft=ruby :
 
 Vagrant.configure('2') do |config|
-    config.vm.box = "remram/ubuntu-1604-amd64-x"
-
     config.vm.provider "virtualbox" do |v|
         #v.gui = true
         v.memory = 2048
     end
 
-    config.vm.network "forwarded_port", guest: 8000, host: 8000
-    config.vm.synced_folder ".", "/home/vagrant/reprozip-examples"
+    # Build VM from this repository, by mounting files and running install.sh
+    config.vm.define "dev", autostart: false do |m|
+        m.vm.box = "remram/ubuntu-1604-amd64-x"
 
-    config.vm.provision "shell", path: "install.sh", privileged: false
+        m.vm.network "forwarded_port", guest: 8000, host: 8001
+        m.vm.synced_folder ".", "/home/vagrant/reprozip-examples"
+
+        m.vm.provision "shell", path: "install.sh", privileged: false
+    end
+
+    # Download pre-built image from OSF.io and run that
+    config.vm.define "prebuilt", autostart: false do |m|
+        m.vm.box = "https://files.osf.io/v1/resources/8uxpv/providers/osfstorage/57ed7933b83f6901ee94b1dd?direct=true&action=download"
+
+        m.vm.network "forwarded_port", guest: 8000, host: 8000
+    end
 end


### PR DESCRIPTION
This makes `vagrant up prebuilt` download the box from OSF.io, and `vagrant up dev` get the base Ubuntu box, mount the repository, and install dependencies.

There needs to be an easy way to use the pre-built box...

One of these could be the default (used when running `vagrant up` or `vagrant ssh` without a box name), not sure?