### PR TITLE
Bechdel package has both fetch&analyze steps

### DIFF
--- a/bechdel-test/README.md
+++ b/bechdel-test/README.md
@@ -35,7 +35,7 @@ Alternatively, you can run the data analysis step (step 2) directly using the da
 ReproZip Package
 ----------------
 
-The ReproZip package is available [here](https://osf.io/r2ptb/) (37.9 MB).
+The ReproZip package is available [here](https://osf.io/q7sdy/) (142 MB).
 
 How to Reproduce
 ----------------


### PR DESCRIPTION
The fetch step seems a bit clunky (encoding import error?) and is likely to fail as URLs disappear or rate-limiting kicks in. It also takes a long time.

Maybe we should replace it with a package that only does the analysis.